### PR TITLE
Adds Erekir units to support-units.js

### DIFF
--- a/scripts/units/support-units.js
+++ b/scripts/units/support-units.js
@@ -1,3 +1,3 @@
 module.exports = [
-    'mono', 'poly', 'mega'
+    'mono', 'poly', 'mega', 'assembly-drone', 'manifold'
 ]


### PR DESCRIPTION
This adds the Cargo Loader drones and Unit Assembler drones(the units in the picture) to be detected as support units for the unit counter.

**However** it might be better to just blacklist them separately instead

![image](https://user-images.githubusercontent.com/22408776/209280077-4ca4c9c2-f10e-4698-89bf-a510bfcee830.png)
